### PR TITLE
Ensure copper features follow layer order

### DIFF
--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -274,6 +274,9 @@ export function convertCircuitJsonToPcbSvg(
     if (elm.type === "pcb_smtpad") {
       return normalizeCopperLayerName(elm.layer)
     }
+    if (elm.type === "pcb_copper_pour") {
+      return normalizeCopperLayerName(elm.layer)
+    }
     if (elm.type === "pcb_trace") {
       for (const seg of elm.route ?? []) {
         const candidates: unknown[] = []
@@ -294,7 +297,11 @@ export function convertCircuitJsonToPcbSvg(
   }
 
   function isCopper(elm: AnyCircuitElement) {
-    return elm.type === "pcb_trace" || elm.type === "pcb_smtpad"
+    return (
+      elm.type === "pcb_trace" ||
+      elm.type === "pcb_smtpad" ||
+      elm.type === "pcb_copper_pour"
+    )
   }
 
   let svgObjects = circuitJson
@@ -312,6 +319,21 @@ export function convertCircuitJsonToPcbSvg(
       )
     })
     .flatMap((elm) => createSvgObjects({ elm, circuitJson, ctx }))
+
+  svgObjects = svgObjects
+    .map((object, index) => ({
+      object,
+      index,
+      layer: normalizeCopperLayerName(object.attributes?.["data-layer"]),
+    }))
+    .sort((a, b) => {
+      if (a.layer && b.layer && a.layer !== b.layer) {
+        return compareCopperLayers(a.layer, b.layer)
+      }
+
+      return a.index - b.index
+    })
+    .map(({ object }) => object)
 
   let strokeWidth = String(0.05 * scaleFactor)
 

--- a/lib/pcb/convert-circuit-json-to-pcb-svg.ts
+++ b/lib/pcb/convert-circuit-json-to-pcb-svg.ts
@@ -1,10 +1,4 @@
-import type {
-  Point,
-  AnyCircuitElement,
-  pcb_cutout,
-  PcbCutout,
-  VisibleLayer,
-} from "circuit-json"
+import type { Point, AnyCircuitElement, pcb_cutout, PcbCutout } from "circuit-json"
 import { type INode as SvgObject, stringify } from "svgson"
 import {
   type Matrix,
@@ -33,12 +27,17 @@ import { createSvgObjectsFromPcbCopperPour } from "./svg-object-fns/create-svg-o
 import {
   DEFAULT_PCB_COLOR_MAP,
   type CopperColorMap,
+  type CopperLayerName,
   type PcbColorMap,
   type PcbColorOverrides,
 } from "./colors"
 import { createSvgObjectsFromPcbComponent } from "./svg-object-fns/create-svg-objects-from-pcb-component"
 import { getSoftwareUsedString } from "../utils/get-software-used-string"
 import { CIRCUIT_TO_SVG_VERSION } from "../package-version"
+import {
+  compareCopperLayers,
+  normalizeCopperLayerName,
+} from "./layer-order"
 
 const OBJECT_ORDER: AnyCircuitElement["type"][] = [
   "pcb_trace_error",
@@ -271,22 +270,23 @@ export function convertCircuitJsonToPcbSvg(
     renderSolderMask: options?.renderSolderMask,
   }
 
-  function getLayer(elm: AnyCircuitElement): VisibleLayer | undefined {
+  function getLayer(elm: AnyCircuitElement): CopperLayerName | undefined {
     if (elm.type === "pcb_smtpad") {
-      return elm.layer === "top" || elm.layer === "bottom"
-        ? elm.layer
-        : undefined
+      return normalizeCopperLayerName(elm.layer)
     }
     if (elm.type === "pcb_trace") {
       for (const seg of elm.route ?? []) {
-        const candidate =
-          ("layer" in seg && seg.layer) ||
-          ("from_layer" in seg && seg.from_layer) ||
-          ("to_layer" in seg && seg.to_layer) ||
-          undefined
+        const candidates: unknown[] = []
 
-        if (candidate === "top" || candidate === "bottom") {
-          return candidate
+        if ("layer" in seg) candidates.push(seg.layer)
+        if ("from_layer" in seg) candidates.push(seg.from_layer)
+        if ("to_layer" in seg) candidates.push(seg.to_layer)
+
+        for (const candidate of candidates) {
+          const normalized = normalizeCopperLayerName(candidate)
+          if (normalized) {
+            return normalized
+          }
         }
       }
     }
@@ -302,11 +302,8 @@ export function convertCircuitJsonToPcbSvg(
       const layerA = getLayer(a)
       const layerB = getLayer(b)
 
-      if (isCopper(a) && isCopper(b) && layerA !== layerB) {
-        if (layerA === "top") return 1
-        if (layerB === "top") return -1
-        if (layerA === "bottom") return -1
-        if (layerB === "bottom") return 1
+      if (isCopper(a) && isCopper(b) && layerA && layerB && layerA !== layerB) {
+        return compareCopperLayers(layerA, layerB)
       }
 
       return (

--- a/lib/pcb/layer-order.ts
+++ b/lib/pcb/layer-order.ts
@@ -1,0 +1,53 @@
+import type { CopperLayerName } from "./colors"
+
+export const COPPER_LAYER_ORDER: readonly CopperLayerName[] = [
+  "bottom",
+  "inner6",
+  "inner5",
+  "inner4",
+  "inner3",
+  "inner2",
+  "inner1",
+  "top",
+] as const
+
+const COPPER_LAYER_PRIORITY: Record<CopperLayerName, number> =
+  COPPER_LAYER_ORDER.reduce(
+    (acc, layer, index) => {
+      acc[layer] = index
+      return acc
+    },
+    {} as Record<CopperLayerName, number>,
+  )
+
+export function isCopperLayerName(
+  layer: unknown,
+): layer is CopperLayerName {
+  if (typeof layer !== "string") return false
+
+  return (COPPER_LAYER_ORDER as readonly string[]).includes(layer)
+}
+
+export function normalizeCopperLayerName(
+  layer: unknown,
+): CopperLayerName | undefined {
+  if (typeof layer === "string") {
+    return isCopperLayerName(layer) ? layer : undefined
+  }
+
+  if (layer && typeof layer === "object" && "name" in layer) {
+    const name = (layer as { name?: unknown }).name
+    return typeof name === "string" && isCopperLayerName(name)
+      ? name
+      : undefined
+  }
+
+  return undefined
+}
+
+export function compareCopperLayers(
+  a: CopperLayerName,
+  b: CopperLayerName,
+): number {
+  return COPPER_LAYER_PRIORITY[a] - COPPER_LAYER_PRIORITY[b]
+}

--- a/lib/pcb/layer-order.ts
+++ b/lib/pcb/layer-order.ts
@@ -20,26 +20,64 @@ const COPPER_LAYER_PRIORITY: Record<CopperLayerName, number> =
     {} as Record<CopperLayerName, number>,
   )
 
+const CANONICAL_LAYER_LOOKUP = COPPER_LAYER_ORDER.reduce(
+  (acc, layer) => {
+    acc.set(layer, layer)
+    acc.set(layer.toLowerCase(), layer)
+    return acc
+  },
+  new Map<string, CopperLayerName>(),
+)
+
+const INNER_LAYER_REGEX = /^inner\s*0*(\d+)$/
+
+function canonicalizeLayerName(
+  value: string,
+): CopperLayerName | undefined {
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+
+  const lower = trimmed.toLowerCase()
+
+  const directMatch = CANONICAL_LAYER_LOOKUP.get(lower)
+  if (directMatch) return directMatch
+
+  const compact = lower.replace(/[^a-z0-9]/g, "")
+  if (!compact) return undefined
+
+  const canonicalFromCompact = CANONICAL_LAYER_LOOKUP.get(compact)
+  if (canonicalFromCompact) return canonicalFromCompact
+
+  const innerMatch = compact.match(INNER_LAYER_REGEX)
+  if (!innerMatch) return undefined
+
+  const innerIndex = Number(innerMatch[1])
+  if (!Number.isFinite(innerIndex) || innerIndex <= 0) return undefined
+
+  const canonical = `inner${innerIndex}` as CopperLayerName
+  return CANONICAL_LAYER_LOOKUP.get(canonical)
+}
+
 export function isCopperLayerName(
   layer: unknown,
 ): layer is CopperLayerName {
   if (typeof layer !== "string") return false
 
-  return (COPPER_LAYER_ORDER as readonly string[]).includes(layer)
+  return Boolean(canonicalizeLayerName(layer))
 }
 
 export function normalizeCopperLayerName(
   layer: unknown,
 ): CopperLayerName | undefined {
   if (typeof layer === "string") {
-    return isCopperLayerName(layer) ? layer : undefined
+    return canonicalizeLayerName(layer)
   }
 
   if (layer && typeof layer === "object" && "name" in layer) {
     const name = (layer as { name?: unknown }).name
-    return typeof name === "string" && isCopperLayerName(name)
-      ? name
-      : undefined
+    if (typeof name === "string") {
+      return canonicalizeLayerName(name)
+    }
   }
 
   return undefined

--- a/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-trace.ts
+++ b/lib/pcb/svg-object-fns/create-svg-objects-from-pcb-trace.ts
@@ -3,6 +3,11 @@ import { pairs } from "lib/utils/pairs"
 import type { INode as SvgObject } from "svgson"
 import { applyToPoint } from "transformation-matrix"
 import { layerNameToColor } from "../layer-name-to-color"
+import {
+  compareCopperLayers,
+  normalizeCopperLayerName,
+} from "../layer-order"
+import type { CopperLayerName } from "../colors"
 import type { PcbContext } from "../convert-circuit-json-to-pcb-svg"
 
 export function createSvgObjectsFromPcbTrace(
@@ -20,8 +25,23 @@ export function createSvgObjectsFromPcbTrace(
     const startPoint = applyToPoint(transform, [start.x, start.y])
     const endPoint = applyToPoint(transform, [end.x, end.y])
 
-    const layer =
-      "layer" in start ? start.layer : "layer" in end ? end.layer : null
+    const possibleLayers: unknown[] = []
+    if ("layer" in start) possibleLayers.push(start.layer)
+    if ("layer" in end) possibleLayers.push(end.layer)
+    if ("from_layer" in start) possibleLayers.push(start.from_layer)
+    if ("from_layer" in end) possibleLayers.push(end.from_layer)
+    if ("to_layer" in start) possibleLayers.push(start.to_layer)
+    if ("to_layer" in end) possibleLayers.push(end.to_layer)
+
+    let layer: CopperLayerName | undefined
+    for (const candidate of possibleLayers) {
+      const normalized = normalizeCopperLayerName(candidate)
+      if (normalized) {
+        layer = normalized
+        break
+      }
+    }
+
     if (!layer) continue
     if (layerFilter && layer !== layerFilter) continue
 
@@ -99,14 +119,11 @@ export function createSvgObjectsFromPcbTrace(
   }
 
   svgObjects.sort((a, b) => {
-    const layerA = a.attributes["data-layer"]
-    const layerB = b.attributes["data-layer"]
+    const layerA = normalizeCopperLayerName(a.attributes["data-layer"])
+    const layerB = normalizeCopperLayerName(b.attributes["data-layer"])
 
-    if (layerA === "bottom" && layerB !== "bottom") {
-      return -1
-    }
-    if (layerA === "top" && layerB !== "top") {
-      return 1
+    if (layerA && layerB && layerA !== layerB) {
+      return compareCopperLayers(layerA, layerB)
     }
     return 0
   })

--- a/tests/pcb/copper-pour-layer-order.test.ts
+++ b/tests/pcb/copper-pour-layer-order.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board = {
+  type: "pcb_board" as const,
+  pcb_board_id: "board",
+  center: { x: 0, y: 0 },
+  width: 10,
+  height: 10,
+}
+
+test("top copper pour renders above bottom copper pour", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_top",
+      layer: "top",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 6,
+      height: 6,
+    },
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_bottom",
+      layer: "bottom",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 6,
+      height: 6,
+    },
+  ] as any)
+
+  const topIndex = svg.indexOf('data-layer="top"')
+  const bottomIndex = svg.indexOf('data-layer="bottom"')
+
+  expect(topIndex).toBeGreaterThan(-1)
+  expect(bottomIndex).toBeGreaterThan(-1)
+  expect(bottomIndex).toBeLessThan(topIndex)
+})


### PR DESCRIPTION
## Summary
- add a shared helper that captures the copper layer stack order
- normalize layer references on traces and pads so inner layers are detected
- sort copper elements using the stack order so traces render from bottom to top

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3dba22d708328a7a4d4f5fe49f161