### PR TITLE
Streamline copper layer handling

### DIFF
--- a/lib/pcb/layer-order.ts
+++ b/lib/pcb/layer-order.ts
@@ -1,0 +1,54 @@
+import type { LayerRef } from "circuit-json"
+import type { CopperLayerName } from "./colors"
+
+export const COPPER_LAYER_ORDER: readonly CopperLayerName[] = [
+  "top",
+  "inner1",
+  "inner2",
+  "inner3",
+  "inner4",
+  "inner5",
+  "inner6",
+  "bottom",
+] as const
+
+const COPPER_LAYER_PRIORITY = new Map(
+  COPPER_LAYER_ORDER.map((layer, index) => [layer, index] as const),
+)
+
+export function isCopperLayerName(layer: string): layer is CopperLayerName {
+  return COPPER_LAYER_PRIORITY.has(layer as CopperLayerName)
+}
+
+export function getCopperLayerName(
+  layer: LayerRef | string | { name?: string } | null | undefined,
+): CopperLayerName | undefined {
+  if (!layer) return undefined
+
+  if (typeof layer === "string") {
+    return isCopperLayerName(layer) ? layer : undefined
+  }
+
+  if (typeof layer === "object") {
+    const name = layer.name
+    if (typeof name === "string" && isCopperLayerName(name)) {
+      return name
+    }
+  }
+
+  return undefined
+}
+
+export function compareCopperLayers(
+  a: CopperLayerName,
+  b: CopperLayerName,
+): number {
+  const priorityA = COPPER_LAYER_PRIORITY.get(a)
+  const priorityB = COPPER_LAYER_PRIORITY.get(b)
+
+  if (priorityA === undefined || priorityB === undefined) {
+    return 0
+  }
+
+  return priorityB - priorityA
+}

--- a/tests/pcb/copper-pour-layer-order.test.ts
+++ b/tests/pcb/copper-pour-layer-order.test.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "bun:test"
+import { convertCircuitJsonToPcbSvg } from "lib"
+
+const board = {
+  type: "pcb_board" as const,
+  pcb_board_id: "board",
+  center: { x: 0, y: 0 },
+  width: 10,
+  height: 10,
+}
+
+test("top copper pour renders above bottom copper pour", () => {
+  const svg = convertCircuitJsonToPcbSvg([
+    board,
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_top",
+      layer: "top",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 6,
+      height: 6,
+    },
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_bottom",
+      layer: "bottom",
+      shape: "rect",
+      center: { x: 0, y: 0 },
+      width: 6,
+      height: 6,
+    },
+  ] as any)
+
+  const topIndex = svg.indexOf('data-layer="top"')
+  const bottomIndex = svg.indexOf('data-layer="bottom"')
+
+  expect(topIndex).toBeGreaterThan(-1)
+  expect(bottomIndex).toBeGreaterThan(-1)
+  expect(bottomIndex).toBeLessThan(topIndex)
+})


### PR DESCRIPTION
## Summary
- replace the copper layer normalization helper with a typed `getCopperLayerName` and priority map for comparisons
- group trace segments by copper layer and emit them in stack order without redundant global sorts
- use typed trace route parsing during SVG assembly to avoid unknown casts while preserving copper ordering

## Testing
- npm run build
- bun test tests/pcb/copper-pour-layer-order.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3dba22d708328a7a4d4f5fe49f161